### PR TITLE
Fix to chords adding themselves multiple times to the stack

### DIFF
--- a/JoyShockMapper/src/main.cpp
+++ b/JoyShockMapper/src/main.cpp
@@ -722,15 +722,17 @@ public:
 	}
 
 	void handleButtonChange(int index, bool pressed) {
-		if(pressed)
-			btnCommon.chordStack.push_front(index); // Always push at the fromt to make it a stack
-		else {
-			auto foundChord = std::find(btnCommon.chordStack.begin(), btnCommon.chordStack.end(), index);
+		auto foundChord = std::find(btnCommon.chordStack.begin(), btnCommon.chordStack.end(), index);
+		if (!pressed)
+		{
 			if (foundChord != btnCommon.chordStack.end())
 			{
 				// The chord is released
 				btnCommon.chordStack.erase(foundChord);
 			}
+		}
+		else if (foundChord == btnCommon.chordStack.end()) {
+			btnCommon.chordStack.push_front(index); // Always push at the fromt to make it a stack
 		}
 
 		switch (buttons[index]._btnState)
@@ -1066,6 +1068,10 @@ public:
 				triggerState[idxState] = DstState::SoftPress;
 				handleButtonChange(softIndex, true);
 			}
+		}
+		else
+		{
+			handleButtonChange(softIndex, false);
 		}
 		break;
 		case DstState::PressStart:


### PR DESCRIPTION
Because "HandleButtonChange" is not called only on change but on every callback, I need to check that the chord is not already in the stack before adding it. This bug would cause the stack to "hoard entries" of the same button as long as it was held, and would progressively release them at the same speed. Whatmore, the trigger handler didn't spam call the release, causing the "stuck chord" bug.