### PR TITLE
[Linux] Only send mouse wheel events on button press

### DIFF
--- a/JoyShockMapper/src/linux/InputHelpers.cpp
+++ b/JoyShockMapper/src/linux/InputHelpers.cpp
@@ -482,13 +482,21 @@ int pressMouse(WORD vkKey, bool isPressed)
 {
 	if (vkKey == V_WHEEL_UP)
 	{
-		mouse.mouse_scroll(1);
+		if (isPressed)
+		{
+			mouse.mouse_scroll(1);
+		}
+
 		return 0;
 	}
 
 	if (vkKey == V_WHEEL_DOWN)
 	{
-		mouse.mouse_scroll(-1);
+		if (isPressed)
+		{
+			mouse.mouse_scroll(-1);
+		}
+
 		return 0;
 	}
 


### PR DESCRIPTION
The current mouse wheel output behavior causes an event to be fired on button press and button release. This change makes sure to only send an event on a button press.