### PR TITLE
Add Stick Sensitivity Per Axis

### DIFF
--- a/JoyShockMapper/src/main.cpp
+++ b/JoyShockMapper/src/main.cpp
@@ -1706,9 +1706,9 @@ void joyShockPollCallback(int jcHandle, JOY_SHOCK_STATE state, JOY_SHOCK_STATE l
 		if (stickLength != 0.0f) {
 			leftAny = true;
 			float warpedStickLengthX = pow(stickLength, jc->getSetting(SettingID::STICK_POWER));
-			float warpedStickLenghtY = warpedStickLengthX;
-			warpedStickLengthX *= jc->getSetting(SettingID::STICK_SENS.first) * jc->getSetting(SettingID::REAL_WORLD_CALIBRATION) / os_mouse_speed / jc->getSetting(SettingID::IN_GAME_SENS);
-			warpedStickLengthY *= jc->getSetting(SettingID::STICK_SENS.second) * jc->getSetting(SettingID::REAL_WORLD_CALIBRATION) / os_mouse_speed / jc->getSetting(SettingID::IN_GAME_SENS);
+			float warpedStickLengthY = warpedStickLengthX;
+			warpedStickLengthX *= jc->getSetting<FloatXY>(SettingID::STICK_SENS).first * jc->getSetting(SettingID::REAL_WORLD_CALIBRATION) / os_mouse_speed / jc->getSetting(SettingID::IN_GAME_SENS);
+			warpedStickLengthY *= jc->getSetting<FloatXY>(SettingID::STICK_SENS).second * jc->getSetting(SettingID::REAL_WORLD_CALIBRATION) / os_mouse_speed / jc->getSetting(SettingID::IN_GAME_SENS);
 			camSpeedX += calX / stickLength * warpedStickLengthX * jc->left_acceleration * deltaTime;
 			camSpeedY += calY / stickLength * warpedStickLengthY * jc->left_acceleration * deltaTime;
 			if (leftPegged) {
@@ -1802,10 +1802,13 @@ void joyShockPollCallback(int jcHandle, JOY_SHOCK_STATE state, JOY_SHOCK_STATE l
 		float stickLength = sqrt(calX * calX + calY * calY);
 		if (stickLength > 0.0f) {
 			rightAny = true;
-			float warpedStickLength = pow(stickLength, jc->getSetting(SettingID::STICK_POWER));
-			warpedStickLength *= jc->getSetting(SettingID::STICK_SENS) * jc->getSetting(SettingID::REAL_WORLD_CALIBRATION) / os_mouse_speed / jc->getSetting(SettingID::IN_GAME_SENS);
-			camSpeedX += calX / stickLength * warpedStickLength * jc->right_acceleration * deltaTime;
-			camSpeedY += calY / stickLength * warpedStickLength * jc->right_acceleration * deltaTime;
+			float warpedStickLengthX = pow(stickLength, jc->getSetting(SettingID::STICK_POWER));
+			float warpedStickLengthY = warpedStickLengthX;
+			warpedStickLengthX *= jc->getSetting<FloatXY>(SettingID::STICK_SENS).first * jc->getSetting(SettingID::REAL_WORLD_CALIBRATION) / os_mouse_speed / jc->getSetting(SettingID::IN_GAME_SENS);
+			warpedStickLengthY *= jc->getSetting<FloatXY>(SettingID::STICK_SENS).second * jc->getSetting(SettingID::REAL_WORLD_CALIBRATION) / os_mouse_speed / jc->getSetting(SettingID::IN_GAME_SENS);
+			camSpeedX += calX / stickLength * warpedStickLengthX * jc->right_acceleration * deltaTime;
+			camSpeedY += calY / stickLength * warpedStickLengthY * jc->right_acceleration * deltaTime;
+			
 			if (rightPegged) {
 				jc->right_acceleration += jc->getSetting(SettingID::STICK_ACCELERATION_RATE) * deltaTime;
 				auto cap = jc->getSetting(SettingID::STICK_ACCELERATION_CAP);


### PR DESCRIPTION
After originally commenting on the recent youtube video by GyroGaming and getting a response that separate stick sensitivity per axis was not implemented I decided that it would be a good first to implement it myself. I followed the same coding convention used currently by the separable axis gyro sensitivity.

Just separate the x and y axis sensitivity in the config with a space (STICK_SENS = 150 20) and the x axis will be the first and y axis will be the second. Only putting one number will set the sensitivity for both (just like it does for gyro).

Note: gyro is not currently working for me in the current source and still doesn't work in the pull. I'll leave that to someone else.