### PR TITLE
Pathfinding fix : reverting previous change

### DIFF
--- a/JoyShockMapper/include/JoyShockMapper.h
+++ b/JoyShockMapper/include/JoyShockMapper.h
@@ -157,6 +157,9 @@ enum class BtnState {
 	DblPressStart, DblPressNoPress, DblPressPress, DblPressWaitHold, DblPressHold, INVALID
 };
 
+// Needs to be accessed publicly
+extern WORD nameToKey(const std::string& name);
+
 struct KeyCode
 {
 	static const KeyCode EMPTY;
@@ -178,9 +181,6 @@ struct KeyCode
 	{
 		return code != 0;
 	}
-
-private:
-	static WORD nameToKey(const std::string &name);
 };
 
 // Used for XY pair values such as sensitivity or GyroSample

--- a/JoyShockMapper/src/win32/InputHelpers.cpp
+++ b/JoyShockMapper/src/win32/InputHelpers.cpp
@@ -142,7 +142,8 @@ BOOL WriteToConsole(const std::string& command)
 		ir.EventType = KEY_EVENT;
 		ir.Event.KeyEvent.bKeyDown = TRUE;
 		ir.Event.KeyEvent.wRepeatCount = 1;
-		auto vkc = char(toupper(c));
+		string name(1, toupper(c));
+		auto vkc = nameToKey(name);
 		ir.Event.KeyEvent.wVirtualKeyCode = vkc;
 		ir.Event.KeyEvent.wVirtualScanCode = MapVirtualKey(vkc, MAPVK_VK_TO_VSC);
 		ir.Event.KeyEvent.uChar.UnicodeChar = c;

--- a/JoyShockMapper/src/win32/PlatformDefinitions.cpp
+++ b/JoyShockMapper/src/win32/PlatformDefinitions.cpp
@@ -21,7 +21,7 @@ const char *BASE_JSM_CONFIG_FOLDER = []{
 /// NONE
 /// And characters: ; ' , . / \ [ ] + - `
 /// Yes, this looks slow. But it's only there to help set up faster mappings
-WORD KeyCode::nameToKey(const std::string &name)
+WORD nameToKey(const std::string &name)
 {
 	// https://msdn.microsoft.com/en-us/library/dd375731%28v=vs.85%29.aspx?f=255&MSPPError=-2147217396
 	auto length = name.length();


### PR DESCRIPTION
I made an error with nameToKey. It needs to be used outside of KeyCode.
It's important for WriteToConsole to work properly.